### PR TITLE
Add elements & text to suggestion board page for demo

### DIFF
--- a/crop-planning/src/pages/Board/suggestionBoard.css
+++ b/crop-planning/src/pages/Board/suggestionBoard.css
@@ -1,0 +1,44 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter&display=swap');
+
+.btn {
+  padding: 10px;
+  font-family: 'Inter', sans-serif;
+  font-size: 18px;
+  margin-bottom: 10px;
+  margin-top:50px;
+  margin-left:20px;
+  border: none;
+  color: white;
+  background-color: black;
+  -moz-border-radius: 10px;
+  -webkit-border-radius: 10px;
+  -o-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.text {
+  font-family: 'Inter', sans-serif;
+  font-size: 22px;
+  color: #0C486B;
+  margin-top: 150px;
+  margin-left: 25px;
+}
+
+.text__analysis {
+  font-family: 'Inter', sans-serif;
+  font-size: 22px;
+  color: #0C486B;
+  margin-top: 100px;
+  margin-left: 25px;
+}
+
+.shadow {
+    color:#0C486B;
+    font-size:16px;
+    text-shadow:
+    -1px -1px 0 #CFF09E,
+    1px -1px 0 #CFF09E,
+    -1px 1px 0 #CFF09E,
+    1px 1px 0 #CFF09E;
+}

--- a/crop-planning/src/pages/suggestionBoard.jsx
+++ b/crop-planning/src/pages/suggestionBoard.jsx
@@ -1,11 +1,38 @@
-import React from "react";
+import React, { useState } from "react";
+import "./Board/suggestionBoard.css"
+import { Link } from "react-router-dom";
 
 const SuggestionBoard = () => {
+    const [showAnalysis, setShowAnalysis] = useState(false);
+    // const [showButton, setShowButton] = useState(false);
+    // const showAlert = () => {
+    //   alert("I'm an alert");
+    // }
+  
     return (
-        <div>
-            <h1>this is suggestion board yahhhh</h1>
-        </div>
+      <>
+      {!showAnalysis? 
+      <div className="text">
+      Analyze your grid layout!
+      </div> : null}
+      
+      {showAnalysis? <div className="text__analysis">
+        <b><i>SoilLab analyzed your grid layout: </i></b><br/>
+        <br/>
+        <b><font color="#3C8586">Carrot at (1,2)</font></b> and <b><font color="#3C8586">Corn at (2,3)</font></b> do not follow the recommended crop distance. <br/>
+        <br/>
+        For the selected season and environment, <b><font color="#3C8586">Rice</font></b> is not recommended.
+        <br/>
+        <br/>
+        <br/>
+        <div className="shadow">Don't agree with our suggestions? Give feedback <Link to="/form">here</Link>.</div>
+      </div> : null}
+
+      {!showAnalysis? <button className="btn" onClick={() => setShowAnalysis(!showAnalysis)}>Show Analysis</button> : null}
+      {showAnalysis? <button className="btn" onClick={() => setShowAnalysis(!showAnalysis)}>Hide Analysis</button> : null}
+      
+      </>
     );
-};  
+  }
 
 export default SuggestionBoard;


### PR DESCRIPTION
In this update:
- Update suggestion board page to show elements/text for demo
- Add 'Show Analysis' button that shows analysis of grid (currently dummy text)
  - Includes display toggle ('Hide Analysis')
- Add link to Form page


<img width="450" alt="image" src="https://user-images.githubusercontent.com/90294056/205853625-4fbf4a22-6892-44f5-94bd-168a27c63d52.png">
<img width="450" alt="image" src="https://user-images.githubusercontent.com/90294056/205853661-38bd5d6e-6d2f-4f9c-968c-dd492fb5ad98.png">
